### PR TITLE
Fix tooltip positioning

### DIFF
--- a/static/collapsible_headings.js
+++ b/static/collapsible_headings.js
@@ -595,6 +595,7 @@
 	 *  @return {Promise}
 	 */
 	function patch_Tooltip () {
+		return Promise.resolve();
 		if (Number(Jupyter.version[0]) >= 5) {
 			return Promise.resolve();
 		}


### PR DESCRIPTION
@jph00 
This PR fixes issue with tooltip now correctly showing up at the right position, depending on the position of the scroll.

For example,
![image](https://github.com/user-attachments/assets/3af1831e-3bc8-44aa-bdf8-66b00c7aaa27)
tooltip shows below the cursor.

![image](https://github.com/user-attachments/assets/ccd1b2d2-f17c-4303-b4d1-c3db79027e5d)
Or above the cursor.

This was due to `Number(Jupyter.version[0])` returning 1 inside `patch_Tooltip` function, and could not get inside of the `if` statement. 